### PR TITLE
feat: enable local listeners as well as tsnet listeners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,4 +47,3 @@ jobs:
 
       - name: Build
         run: nix build .#libations
-          

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,8 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
-    name: Test
+  test-tsnet:
+    name: Test (tsnet)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -64,3 +64,36 @@ jobs:
           token="$(curl -s -d "client_id=$TS_CLIENT" -d "client_secret=$TS_SECRET" "https://api.tailscale.com/api/v2/oauth/token" | jq -r '.access_token')"
 
           curl -s -u "${token}:" -X DELETE "https://api.tailscale.com/api/v2/device/${id}"
+
+  test-local:
+    name: Test (local)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Setup magic-nix-cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build Libations
+        run: |
+          nix build .#libations
+  
+      - name: Run Libations
+        run: |
+          # Start Libations in the background
+          ./result/bin/libations -hostname "libations-$HOSTNAME" -local -addr=":8081" &>~/libations.log &
+
+          curl --connect-timeout 30 --retry 300 --retry-delay 5 "http://localhost:8081"
+
+      - name: Dump Libations logs
+        run: |
+          cat ~/libations.log

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Libations
 
 This is a simple static website for hosting cocktail recipes. The actual site is built using [Hugo]
-and served over Tailscale (using [tsnet]) by a simple Go binary that embeds the page. The page is
-designed to be viewed on a mobile - it works _okay_ on bigger screens, but I've not yet made that
-look "right".
+and served by default over Tailscale (using [tsnet]) by a simple Go binary that embeds the page.
+The page is designed to be viewed on a mobile - it works _okay_ on bigger screens, but I've not yet
+made that look "right".
 
 The page is styled with the excellent [Vanilla Framework], because that's what I had to hand.
-Despite appearances, this site has nothing to do with [Canonical] 😉.
 
 Cocktail recipes are served up from a JSON file containing the recipes. The format is listed in a
 section below. There is an example [included](./webui/data/drinks.json).
@@ -16,6 +15,21 @@ section below. There is an example [included](./webui/data/drinks.json).
 </p>
 
 ## Usage
+
+### Command line flags
+
+```
+./libations -help
+Usage of /bin/libations:
+  -addr string
+        the address to listen on in the case of a local listener (default ":8080")
+  -hostname string
+        hostname to use on the tailnet (default "libations")
+  -local
+        start on local addr; don't attach to a tailnet
+  -tsnet-logs
+        include tsnet logs in application logs (default true)
+```
 
 ### Using Nix
 


### PR DESCRIPTION
Adds the ability to listen locally, instead of using `tsnet` if that is preferred.

Fixes #1 